### PR TITLE
Add Sicoob PDF parser with OCR fallback

### DIFF
--- a/backend/parsers/__init__.py
+++ b/backend/parsers/__init__.py
@@ -1,0 +1,30 @@
+from importlib import import_module
+import pkgutil
+from typing import Callable, Dict
+
+_parsers: Dict[str, Callable[[bytes], dict]] = {}
+
+
+def register(name: str):
+    def decorator(func: Callable[[bytes], dict]):
+        _parsers[name] = func
+        return func
+
+    return decorator
+
+
+def get(name: str) -> Callable[[bytes], dict]:
+    return _parsers[name]
+
+
+def parse(name: str, pdf_bytes: bytes) -> dict:
+    parser = get(name)
+    return parser(pdf_bytes)
+
+
+def _load_plugins() -> None:
+    for _, module_name, _ in pkgutil.iter_modules(__path__):
+        import_module(f"{__name__}.{module_name}")
+
+
+_load_plugins()

--- a/backend/parsers/sicoob.py
+++ b/backend/parsers/sicoob.py
@@ -1,0 +1,23 @@
+import io
+from pdf2image import convert_from_bytes
+import pdfplumber
+from pytesseract import image_to_string
+
+from . import register
+
+
+@register("sicoob")
+def parse(pdf_bytes: bytes) -> dict:
+    """Parse Sicoob loan contract PDF bytes into structured data.
+
+    The parser first attempts to extract text using pdfplumber. If the PDF
+    contains only images, it falls back to OCR using Tesseract.
+    """
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        text = "\n".join(page.extract_text() or "" for page in pdf.pages)
+
+    if not text.strip():
+        images = convert_from_bytes(pdf_bytes)
+        text = "\n".join(image_to_string(img, lang="por") for img in images)
+
+    return {"raw_text": text.strip()}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,6 @@ fastapi
 uvicorn
 redis
 rq
+pdfplumber
+pdf2image
+pytesseract

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,3 +1,16 @@
-def parse_sicoob(filepath: str) -> None:
-    """Placeholder for Sicoob PDF parsing logic."""
-    print(f"Parsing Sicoob PDF: {filepath}")
+from pathlib import Path
+from typing import Any
+
+from .parsers import parse
+
+
+def parse_sicoob(filepath: str) -> dict:
+    """Parse a Sicoob PDF contract using the registered parser.
+
+    If parsing fails, the contract is marked as "pendente revisão".
+    """
+    pdf_bytes = Path(filepath).read_bytes()
+    try:
+        return parse("sicoob", pdf_bytes)
+    except Exception as exc:
+        return {"status": "pendente revisão", "error": str(exc)}


### PR DESCRIPTION
## Summary
- add plugin registry for parsers
- implement Sicoob parser with OCR fallback
- mark parsing failures as `pendente revisão`
- include parsing dependencies

## Testing
- `python -m py_compile backend/parsers/__init__.py backend/parsers/sicoob.py backend/tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_68936c81aaac832f8f8527d633f388e8