### PR TITLE
feat: parse Sicoob statements

### DIFF
--- a/backend/parsers/sicoob.py
+++ b/backend/parsers/sicoob.py
@@ -1,4 +1,7 @@
 import io
+import re
+from typing import List, Dict, Optional
+
 from pdf2image import convert_from_bytes
 import pdfplumber
 from pytesseract import image_to_string
@@ -6,13 +9,32 @@ from pytesseract import image_to_string
 from . import register
 
 
+def _parse_currency(value: str) -> Optional[float]:
+    """Convert Brazilian formatted currency to float.
+
+    Returns ``None`` for empty fields represented by ``-``. Raises ``ValueError``
+    for any other malformed value.
+    """
+
+    value = value.strip()
+    if value in {"", "-"}:
+        return None
+
+    value = value.replace(".", "").replace(",", ".")
+    try:
+        return float(value)
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise ValueError(f"Valor monetário inválido: {value}") from exc
+
+
 @register("sicoob")
-def parse(pdf_bytes: bytes) -> dict:
+def parse(pdf_bytes: bytes) -> Dict[str, List[Dict[str, Optional[float]]]]:
     """Parse Sicoob loan contract PDF bytes into structured data.
 
     The parser first attempts to extract text using pdfplumber. If the PDF
     contains only images, it falls back to OCR using Tesseract.
     """
+
     with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
         text = "\n".join(page.extract_text() or "" for page in pdf.pages)
 
@@ -20,4 +42,54 @@ def parse(pdf_bytes: bytes) -> dict:
         images = convert_from_bytes(pdf_bytes)
         text = "\n".join(image_to_string(img, lang="por") for img in images)
 
-    return {"raw_text": text.strip()}
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+
+    # Locate the table header which contains the data labels
+    header_idx = None
+    for i, line in enumerate(lines):
+        if re.search(r"data\s+ref", line, re.IGNORECASE) and re.search(
+            r"data\s+lan", line, re.IGNORECASE
+        ):
+            header_idx = i
+            break
+
+    if header_idx is None:
+        raise ValueError("Cabeçalho da tabela não encontrado")
+
+    header = lines[:header_idx]
+    data_lines = lines[header_idx + 1 :]
+
+    pattern = re.compile(
+        r"^(?P<data_ref>\d{2}/\d{2}/\d{4})\s+"
+        r"(?P<data_lanc>\d{2}/\d{2}/\d{4})\s+"
+        r"(?P<descricao>.*?)\s+"
+        r"(?P<valor_debito>-|[\d.,]+)\s+"
+        r"(?P<valor_credito>-|[\d.,]+)\s+"
+        r"(?P<saldo>[\d.,]+)$"
+    )
+
+    transactions: List[Dict[str, Optional[float]]] = []
+    for line in data_lines:
+        if not re.match(r"^\d{2}/\d{2}/\d{4}", line):
+            # Ignore lines that do not start with a date
+            continue
+
+        match = pattern.match(line)
+        if not match:
+            raise ValueError(f"Linha de movimentação inválida: {line}")
+
+        transactions.append(
+            {
+                "data_ref": match.group("data_ref"),
+                "data_lanc": match.group("data_lanc"),
+                "descricao": match.group("descricao").strip(),
+                "valor_debito": _parse_currency(match.group("valor_debito")),
+                "valor_credito": _parse_currency(match.group("valor_credito")),
+                "saldo": _parse_currency(match.group("saldo")),
+            }
+        )
+
+    if not transactions:
+        raise ValueError("Nenhuma movimentação encontrada")
+
+    return {"header": header, "transactions": transactions}

--- a/backend/tests/test_sicoob_parser.py
+++ b/backend/tests/test_sicoob_parser.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+
+# Ensure the backend package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from parsers.sicoob import parse
+
+
+class DummyPage:
+    def __init__(self, text: str):
+        self._text = text
+
+    def extract_text(self):
+        return self._text
+
+
+class DummyPDF:
+    def __init__(self, text: str):
+        self.pages = [DummyPage(text)]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+TEXT_CONTENT = "\n".join(
+    [
+        "Sicoob",
+        "Extrato de Conta Corrente",
+        "Agencia: 1234 Conta: 56789-0",
+        "Data Ref Data Lanc Descricao Valor Debito Valor Credito Saldo",
+        "01/01/2023 01/01/2023 Deposito inicial - 1.000,00 1.000,00",
+        "02/01/2023 02/01/2023 Saque 100,00 - 900,00",
+    ]
+)
+
+
+def test_parse_text_pdf(monkeypatch):
+    def fake_open(*args, **kwargs):
+        return DummyPDF(TEXT_CONTENT)
+
+    monkeypatch.setattr("parsers.sicoob.pdfplumber.open", fake_open)
+
+    result = parse(b"")
+
+    assert result["header"][0] == "Sicoob"
+    assert len(result["transactions"]) == 2
+    first = result["transactions"][0]
+    assert first["data_ref"] == "01/01/2023"
+    assert first["valor_credito"] == 1000.00
+    second = result["transactions"][1]
+    assert second["valor_debito"] == 100.00
+
+
+def test_parse_image_pdf(monkeypatch):
+    def fake_open(*args, **kwargs):
+        return DummyPDF("")
+
+    def fake_convert_from_bytes(*args, **kwargs):
+        return [object()]
+
+    def fake_image_to_string(*args, **kwargs):
+        return TEXT_CONTENT
+
+    monkeypatch.setattr("parsers.sicoob.pdfplumber.open", fake_open)
+    monkeypatch.setattr("parsers.sicoob.convert_from_bytes", fake_convert_from_bytes)
+    monkeypatch.setattr("parsers.sicoob.image_to_string", fake_image_to_string)
+
+    result = parse(b"")
+
+    assert len(result["transactions"]) == 2
+    assert result["transactions"][0]["data_ref"] == "01/01/2023"


### PR DESCRIPTION
## Summary
- parse Sicoob PDFs and extract transactions
- add Sicoob parser tests with OCR coverage
- drop binary fixtures by mocking PDF and OCR helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893bae62048832fba98e7256592aac3