### PR TITLE
feat: persist parsed statements

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, Date, ForeignKey
+from sqlalchemy import Column, Integer, String, Float, Date, ForeignKey, JSON
 from sqlalchemy.orm import relationship
 
 from .db import Base
@@ -26,3 +26,32 @@ class Contrato(Base):
     data_inicio = Column(Date, nullable=False)
 
     empresa = relationship("Empresa", back_populates="contratos")
+    extratos = relationship("Extrato", back_populates="contrato")
+
+
+class Extrato(Base):
+    __tablename__ = "extratos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    contrato_id = Column(Integer, ForeignKey("contratos.id"), nullable=False)
+    filepath = Column(String, nullable=False)
+    status = Column(String, nullable=False)
+    metadata = Column(JSON, nullable=True)
+
+    contrato = relationship("Contrato", back_populates="extratos")
+    movimentacoes = relationship("Movimentacao", back_populates="extrato")
+
+
+class Movimentacao(Base):
+    __tablename__ = "movimentacoes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    extrato_id = Column(Integer, ForeignKey("extratos.id"), nullable=False)
+    data_ref = Column(Date)
+    data_lanc = Column(Date)
+    descricao = Column(String)
+    valor_debito = Column(Float)
+    valor_credito = Column(Float)
+    saldo = Column(Float)
+
+    extrato = relationship("Extrato", back_populates="movimentacoes")

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,16 +1,100 @@
-from pathlib import Path
-from typing import Any
+"""Background tasks for processing bank statements."""
 
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .db import SessionLocal
+from .models import Extrato, Movimentacao
 from .parsers import parse
 
+logger = logging.getLogger(__name__)
 
-def parse_sicoob(filepath: str) -> dict:
-    """Parse a Sicoob PDF contract using the registered parser.
 
-    If parsing fails, the contract is marked as "pendente revisão".
+def _parse_date(value: Optional[str]):
+    """Convert a ``dd/mm/YYYY`` string to ``date``.
+
+    Returns ``None`` for falsy values or malformed strings.
     """
-    pdf_bytes = Path(filepath).read_bytes()
+
+    if not value:
+        return None
     try:
-        return parse("sicoob", pdf_bytes)
-    except Exception as exc:
-        return {"status": "pendente revisão", "error": str(exc)}
+        return datetime.strptime(value, "%d/%m/%Y").date()
+    except ValueError:  # pragma: no cover - defensive
+        return None
+
+
+def parse_sicoob(filepath: str, contrato_id: Optional[int] = None) -> Dict[str, Any]:
+    """Parse a Sicoob PDF and persist its data to the database.
+
+    On success an ``Extrato`` record is created with status ``importado`` and all
+    extracted ``Movimentacao`` rows are associated with it. If parsing fails the
+    ``Extrato`` is marked as ``pendente revisão``. Any unexpected database errors
+    mark the ``Extrato`` as ``erro``.
+    """
+
+    pdf_bytes = Path(filepath).read_bytes()
+    session = SessionLocal()
+
+    try:
+        try:
+            data = parse("sicoob", pdf_bytes)
+        except Exception as exc:
+            logger.error("Falha ao interpretar extrato %s: %s", filepath, exc)
+            extrato = Extrato(
+                contrato_id=contrato_id,
+                filepath=filepath,
+                status="pendente revisão",
+                metadata={"error": str(exc)},
+            )
+            session.add(extrato)
+            session.commit()
+            return {"status": "pendente revisão", "error": str(exc)}
+
+        extrato = Extrato(
+            contrato_id=contrato_id,
+            filepath=filepath,
+            status="importado",
+            metadata={"header": data.get("header")},
+        )
+        session.add(extrato)
+        session.flush()  # obtain extrato.id
+
+        transactions: List[Dict[str, Any]] = data.get("transactions", [])
+        for tx in transactions:
+            mov = Movimentacao(
+                extrato_id=extrato.id,
+                data_ref=_parse_date(tx.get("data_ref")),
+                data_lanc=_parse_date(tx.get("data_lanc")),
+                descricao=tx.get("descricao"),
+                valor_debito=tx.get("valor_debito"),
+                valor_credito=tx.get("valor_credito"),
+                saldo=tx.get("saldo"),
+            )
+            session.add(mov)
+
+        session.commit()
+        logger.info(
+            "Extrato %s importado com %d movimentacoes", filepath, len(transactions)
+        )
+        return data
+
+    except Exception as exc:  # pragma: no cover - defensive
+        session.rollback()
+        logger.exception("Erro ao salvar extrato %s", filepath)
+        extrato = Extrato(
+            contrato_id=contrato_id,
+            filepath=filepath,
+            status="erro",
+            metadata={"error": str(exc)},
+        )
+        session.add(extrato)
+        session.commit()
+        return {"status": "erro", "error": str(exc)}
+    finally:
+        session.close()
+


### PR DESCRIPTION
## Summary
- add Extrato and Movimentacao models
- persist parsed statement data and transactions in background task with detailed logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a1330080832f8181aca610112fef