### PR TITLE
feat: add bank statement upload

### DIFF
--- a/frontend/src/components/UploadExtrato.tsx
+++ b/frontend/src/components/UploadExtrato.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+
+interface Props {
+  contractId: string
+  onClose: () => void
+}
+
+export default function UploadExtrato({ contractId, onClose }: Props) {
+  const [file, setFile] = useState<File | null>(null)
+  const [status, setStatus] = useState<'idle' | 'uploading' | 'success' | 'error'>('idle')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!file) return
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('contract_id', contractId)
+    try {
+      setStatus('uploading')
+      const res = await fetch('/uploads', {
+        method: 'POST',
+        body: formData,
+      })
+      if (!res.ok) throw new Error('Upload failed')
+      setStatus('success')
+    } catch (err) {
+      console.error(err)
+      setStatus('error')
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="bg-white p-4 rounded space-y-4">
+        <h2 className="text-lg font-bold">Importar Extrato</h2>
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+            disabled={!file || status === 'uploading'}
+          >
+            Enviar
+          </button>
+          <button
+            type="button"
+            className="px-4 py-2"
+            onClick={onClose}
+            disabled={status === 'uploading'}
+          >
+            Cancelar
+          </button>
+        </div>
+        {status === 'uploading' && <p>Enviando...</p>}
+        {status === 'success' && <p className="text-green-600">Arquivo enviado!</p>}
+        {status === 'error' && <p className="text-red-600">Erro ao enviar.</p>}
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/Contratos.tsx
+++ b/frontend/src/pages/Contratos.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import UploadExtrato from '@/components/UploadExtrato'
 
 interface Contract {
   id: string
@@ -25,6 +26,7 @@ export default function Contratos() {
   const [dueFilter, setDueFilter] = useState('')
   const [startExport, setStartExport] = useState('')
   const [endExport, setEndExport] = useState('')
+  const [uploadContract, setUploadContract] = useState<string | null>(null)
 
   useEffect(() => {
     fetch('/contracts')
@@ -121,10 +123,11 @@ export default function Contratos() {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Banco</TableHead>
-            <TableHead>Saldo</TableHead>
-            <TableHead>CET</TableHead>
-            <TableHead>Vencimento</TableHead>
+          <TableHead>Banco</TableHead>
+          <TableHead>Saldo</TableHead>
+          <TableHead>CET</TableHead>
+          <TableHead>Vencimento</TableHead>
+          <TableHead>Ações</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -132,17 +135,31 @@ export default function Contratos() {
             <TableRow key={c.id}>
               <TableCell>{c.bank}</TableCell>
               <TableCell>
-                {c.balance.toLocaleString('pt-BR', {
-                  style: 'currency',
-                  currency: 'BRL',
-                })}
-              </TableCell>
-              <TableCell>{c.cet}%</TableCell>
-              <TableCell>{c.dueDate}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+              {c.balance.toLocaleString('pt-BR', {
+                style: 'currency',
+                currency: 'BRL',
+              })}
+            </TableCell>
+            <TableCell>{c.cet}%</TableCell>
+            <TableCell>{c.dueDate}</TableCell>
+            <TableCell>
+              <button
+                className="px-2 py-1 bg-green-600 text-white rounded"
+                onClick={() => setUploadContract(c.id)}
+              >
+                Importar Extrato
+              </button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+    {uploadContract && (
+      <UploadExtrato
+        contractId={uploadContract}
+        onClose={() => setUploadContract(null)}
+      />
+    )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add UploadExtrato component for uploading contract statements
- allow importing extrato per contract in list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894aa56e1bc832f8000ba2bf41e7327