### PR TITLE
refactor: centralize redis configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ Plataforma para processamento e análise de contratos de empréstimo.
    ```bash
    export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
    ```
-4. Iniciar o servidor FastAPI:
+4. (Opcional) Configurar o acesso ao Redis via variáveis de ambiente:
+   ```bash
+   export REDIS_HOST=localhost
+   export REDIS_PORT=6379
+   ```
+5. Iniciar o servidor FastAPI:
    ```bash
    uvicorn backend.main:app --reload
    ```
@@ -46,8 +51,9 @@ npm test
 ### Worker
 1. Em outro terminal, iniciar o worker RQ:
    ```bash
-   python backend/worker.py
+   python -m backend.worker
    ```
+   As variáveis `REDIS_HOST` e `REDIS_PORT` também são respeitadas aqui.
 
 ### Node
 1. Instalar dependências do frontend:

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,14 @@
+import os
+from redis import Redis
+from functools import lru_cache
+
+@lru_cache()
+def get_redis() -> Redis:
+    """Return a Redis connection using environment variables.
+
+    The host and port are read from ``REDIS_HOST`` and ``REDIS_PORT``
+    variables, defaulting to ``redis`` and ``6379`` respectively.
+    """
+    host = os.environ.get("REDIS_HOST", "redis")
+    port = int(os.environ.get("REDIS_PORT", 6379))
+    return Redis(host=host, port=port)

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,10 +9,10 @@ from typing import List, Tuple, Iterable
 from fastapi import Depends, FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from redis import Redis
 from rq import Queue
 from sqlalchemy.orm import Session
 
+from backend.config import get_redis
 from .db import SessionLocal
 from .models import Contrato, Movimentacao, Extrato
 
@@ -31,9 +31,7 @@ class ContractResponse(BaseModel):
 app = FastAPI()
 logger = logging.getLogger(__name__)
 
-redis_host = os.environ.get("REDIS_HOST", "redis")
-redis_port = int(os.environ.get("REDIS_PORT", 6379))
-redis_conn = Redis(host=redis_host, port=redis_port)
+redis_conn = get_redis()
 queue = Queue("uploads", connection=redis_conn)
 
 storage_path = os.environ.get("UPLOAD_DIR", "storage")

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,15 +1,12 @@
-import os
-from redis import Redis
 from rq import Connection, Worker, Queue
+
+from backend.config import get_redis
 
 listen = ["uploads"]
 
-redis_host = os.environ.get("REDIS_HOST", "redis")
-redis_port = int(os.environ.get("REDIS_PORT", 6379))
-
 
 def run_worker() -> None:
-    redis_conn = Redis(host=redis_host, port=redis_port)
+    redis_conn = get_redis()
     with Connection(redis_conn):
         worker = Worker(list(map(Queue, listen)))
         worker.work()


### PR DESCRIPTION
## Summary
- add shared `get_redis` helper to read Redis host/port from environment
- use centralized Redis connection in main API and worker
- document Redis configuration and worker startup in README

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895054c6bbc832f9bca4b3cdaf1b2c3