### PR TITLE
Add contract id to uploads and validate contract association

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -62,7 +62,7 @@ def list_contracts(db: Session = Depends(get_db)):
     ]
 
 @app.post("/uploads")
-async def upload_pdf(file: UploadFile = File(...)):
+async def upload_pdf(contract_id: int, file: UploadFile = File(...)):
     logger.info("Upload started for file '%s'", file.filename)
     if file.content_type != "application/pdf":
         raise HTTPException(status_code=400, detail="Only PDF files are supported")
@@ -77,7 +77,7 @@ async def upload_pdf(file: UploadFile = File(...)):
     except OSError as e:
         logger.exception("Failed to save uploaded file '%s'", file.filename)
         raise HTTPException(status_code=500, detail="Failed to save file") from e
-    queue.enqueue("tasks.parse_sicoob", dest)
+    queue.enqueue("tasks.parse_sicoob", dest, contract_id)
     logger.info("Upload finished for file '%s' as '%s'", file.filename, file_id)
     return {"id": file_id, "filename": file.filename}
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -26,20 +26,20 @@ class Contrato(Base):
     data_inicio = Column(Date, nullable=False)
 
     empresa = relationship("Empresa", back_populates="contratos")
-    extratos = relationship("Extrato", back_populates="contrato")
+    extratos = relationship("Extrato", back_populates="contrato", cascade="all, delete-orphan")
 
 
 class Extrato(Base):
     __tablename__ = "extratos"
 
     id = Column(Integer, primary_key=True, index=True)
-    contrato_id = Column(Integer, ForeignKey("contratos.id"), nullable=False)
+    contrato_id = Column(Integer, ForeignKey("contratos.id"), nullable=True)
     filepath = Column(String, nullable=False)
     status = Column(String, nullable=False)
     meta = Column("metadata", JSON, nullable=True)
 
     contrato = relationship("Contrato", back_populates="extratos")
-    movimentacoes = relationship("Movimentacao", back_populates="extrato")
+    movimentacoes = relationship("Movimentacao", back_populates="extrato", cascade="all, delete-orphan")
 
 
 class Movimentacao(Base):

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -1,0 +1,89 @@
+from datetime import date
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.db import Base
+from backend import tasks
+from backend.models import Contrato, Empresa, Extrato
+
+
+def _setup_db(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path}/test.db", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal
+
+
+def test_parse_sicoob_invalid_contract(tmp_path, monkeypatch):
+    Session = _setup_db(tmp_path)
+    monkeypatch.setattr(tasks, "SessionLocal", Session)
+    monkeypatch.setattr(tasks, "parse", lambda *args, **kwargs: {"header": [], "transactions": []})
+
+    pdf_path = Path(tmp_path) / "dummy.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+
+    result = tasks.parse_sicoob(str(pdf_path), contract_id=999)
+    assert result["status"] == "erro"
+
+    session = Session()
+    extratos = session.query(Extrato).all()
+    session.close()
+
+    assert len(extratos) == 1
+    assert extratos[0].contrato_id is None
+
+
+def test_parse_sicoob_persists_data(tmp_path, monkeypatch):
+    Session = _setup_db(tmp_path)
+    monkeypatch.setattr(tasks, "SessionLocal", Session)
+
+    # create required Empresa and Contrato
+    session = Session()
+    empresa = Empresa(nome="ACME", cnpj="123")
+    session.add(empresa)
+    session.flush()
+    contrato = Contrato(
+        empresa_id=empresa.id,
+        numero="1",
+        banco="Sicoob",
+        saldo=1000.0,
+        taxa_anual=0.1,
+        data_inicio=date(2023, 1, 1),
+    )
+    session.add(contrato)
+    session.commit()
+    contrato_id = contrato.id
+    session.close()
+
+    monkeypatch.setattr(
+        tasks,
+        "parse",
+        lambda *args, **kwargs: {
+            "header": ["Sicoob"],
+            "transactions": [
+                {
+                    "data_ref": "01/01/2023",
+                    "data_lanc": "01/01/2023",
+                    "descricao": "x",
+                    "valor_debito": None,
+                    "valor_credito": 1.0,
+                    "saldo": 1.0,
+                }
+            ],
+        },
+    )
+
+    pdf_path = Path(tmp_path) / "dummy.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+
+    result = tasks.parse_sicoob(str(pdf_path), contract_id=contrato_id)
+    assert result["transactions"]
+
+    session = Session()
+    extratos = session.query(Extrato).all()
+    session.close()
+
+    assert len(extratos) == 1
+    assert extratos[0].contrato_id == contrato_id


### PR DESCRIPTION
## Summary
- require contract_id in `/uploads` and forward it to background parsing
- validate contract existence in `parse_sicoob` and handle missing contracts
- allow statements without a linked contract and cascade related records
- add tests for upload contract parameter and parsing logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899e8eb6820832fbebd6321245d4718