### PR TITLE
Load account rules from external config

### DIFF
--- a/backend/account_rules.json
+++ b/backend/account_rules.json
@@ -1,0 +1,12 @@
+{
+  "account_map": {
+    "liberacao": ["111", "211"],
+    "juros": ["631", "111"],
+    "amortizacao": ["211", "111"]
+  },
+  "classify_rules": [
+    {"keyword": "libera", "account": "liberacao"},
+    {"keyword": "juros", "account": "juros"},
+    {"keyword": "amort", "account": "amortizacao"}
+  ]
+}

--- a/backend/rules.py
+++ b/backend/rules.py
@@ -1,0 +1,25 @@
+import json
+import os
+from typing import Tuple
+
+CONFIG_PATH = os.environ.get(
+    "ACCOUNT_RULES_PATH", os.path.join(os.path.dirname(__file__), "account_rules.json")
+)
+
+def load_config() -> dict:
+    """Load classification rules from JSON configuration."""
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def classify(desc: str) -> Tuple[str, str]:
+    """Classify a description using rules from configuration."""
+    cfg = load_config()
+    account_map = cfg.get("account_map", {})
+    d = desc.lower()
+    for rule in cfg.get("classify_rules", []):
+        keyword = rule.get("keyword", "").lower()
+        if keyword and keyword in d:
+            accounts = account_map.get(rule.get("account"))
+            if accounts:
+                return tuple(accounts)
+    return ("000", "000")

--- a/backend/tests/test_rules.py
+++ b/backend/tests/test_rules.py
@@ -1,0 +1,16 @@
+import json
+from importlib import reload
+import backend.rules as rules
+
+def test_classify_uses_config(tmp_path, monkeypatch):
+    cfg = {
+        "account_map": {"test": ["123", "321"]},
+        "classify_rules": [{"keyword": "sample", "account": "test"}],
+    }
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text(json.dumps(cfg))
+
+    monkeypatch.setenv("ACCOUNT_RULES_PATH", str(cfg_file))
+    reload(rules)
+    assert rules.classify("sample description") == ("123", "321")
+    assert rules.classify("other") == ("000", "000")


### PR DESCRIPTION
## Summary
- load account and classification rules from JSON file
- expose classify function through new rules module
- verify dynamic configuration with tests

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f3397700832f83bd0c3685c2f500