### PR TITLE
Stream accrual export contract query

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -106,7 +106,11 @@ def export_accruals(start_date: str, end_date: str, db: Session = Depends(get_db
         writer.writerow(["contract_id", "principal", "annual_rate", "days", "interest"])
         yield header_buffer.getvalue()
 
-        contracts = db.query(Contrato).all()
+        contracts = (
+            db.query(Contrato)
+            .filter(Contrato.data_inicio <= end)
+            .yield_per(100)
+        )
         for contract in contracts:
             contract_start = contract.data_inicio
             period_start = max(start, contract_start)


### PR DESCRIPTION
## Summary
- filter contracts by start date before accrual export processing
- stream contract results using SQLAlchemy `yield_per`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899f9390508832fab8aff4ae70eba09