### PR TITLE
feat(frontend): centralize fetch via API utility

### DIFF
--- a/frontend/src/components/UploadExtrato.tsx
+++ b/frontend/src/components/UploadExtrato.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { api } from '@/lib/api'
 
 interface Props {
   contractId: string
@@ -17,7 +18,7 @@ export default function UploadExtrato({ contractId, onClose }: Props) {
     formData.append('contract_id', contractId)
     try {
       setStatus('uploading')
-      const res = await fetch('/uploads', {
+      const res = await api('/uploads', {
         method: 'POST',
         body: formData,
       })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,5 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+
+export function api(path: string, init?: RequestInit) {
+  return fetch(`${API_BASE_URL}${path}`, init)
+}

--- a/frontend/src/pages/Contratos.test.tsx
+++ b/frontend/src/pages/Contratos.test.tsx
@@ -1,12 +1,12 @@
-import { beforeEach, vi, describe, it, expect } from 'vitest'
+import { vi, describe, it, expect } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render, screen } from '@testing-library/react'
 
 import Contratos from './Contratos'
 
-beforeEach(() => {
-  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }))
-})
+vi.mock('@/lib/api', () => ({
+  api: vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }),
+}))
 
 describe('Contratos', () => {
   it('renderiza título', () => {

--- a/frontend/src/pages/Contratos.tsx
+++ b/frontend/src/pages/Contratos.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import UploadExtrato from '@/components/UploadExtrato'
+import { api } from '@/lib/api'
 
 interface Contract {
   id: string
@@ -30,7 +31,7 @@ export default function Contratos() {
   const [isExporting, setIsExporting] = useState(false)
 
   useEffect(() => {
-    fetch('/contracts')
+    api('/contracts')
       .then((res) => res.json())
       .then(setContracts)
       .catch((err) => console.error('Failed to load contracts', err))
@@ -54,7 +55,7 @@ export default function Contratos() {
         start_date: startExport,
         end_date: endExport,
       })
-      const res = await fetch(`/accruals/export?${params.toString()}`)
+      const res = await api(`/accruals/export?${params.toString()}`)
       if (!res.ok) {
         throw new Error('Resposta não OK')
       }


### PR DESCRIPTION
## Summary
- add api helper reading `VITE_API_BASE_URL`
- replace direct fetch calls with api helper
- adjust tests to mock api helper

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899fb6f8a08832fbb217564caa50406