### PR TITLE
Exibe detalhe de erros nas respostas da API

### DIFF
--- a/frontend/src/pages/Contratos.tsx
+++ b/frontend/src/pages/Contratos.tsx
@@ -57,7 +57,14 @@ export default function Contratos() {
       })
       const res = await api(`/accruals/export?${params.toString()}`)
       if (!res.ok) {
-        throw new Error('Resposta não OK')
+        let message = 'Não foi possível exportar os juros. Tente novamente mais tarde.'
+        try {
+          const data = await res.json()
+          message = data.detail ?? message
+        } catch {
+          // ignore
+        }
+        throw new Error(message)
       }
       const blob = await res.blob()
       const url = window.URL.createObjectURL(blob)
@@ -71,7 +78,11 @@ export default function Contratos() {
       console.log('Exportação concluída com sucesso')
     } catch (err) {
       console.error('Erro ao exportar juros', err)
-      alert('Não foi possível exportar os juros. Tente novamente mais tarde.')
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'Não foi possível exportar os juros. Tente novamente mais tarde.'
+      alert(message)
     } finally {
       setIsExporting(false)
     }


### PR DESCRIPTION
## Summary
- exibe mensagem detalhada ao exportar juros quando a API retorna erro
- mostra detalhe de falha no upload de extrato com fallback genérico

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899fda7fa00832faed90878489ddace