### PR TITLE
chore: add docker compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,17 @@ npm test
    npm install
    ```
 
-### Redis e PostgreSQL via Docker
-1. Subir serviços com Docker:
+### Docker Compose
+1. Subir backend, frontend, Redis e PostgreSQL:
    ```bash
-   docker run --name redis -p 6379:6379 -d redis
-   docker run --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres
+   docker-compose up --build
+   ```
+   Backend em http://localhost:8000
+   Frontend em http://localhost:5173
+
+2. Parar e remover containers:
+   ```bash
+   docker-compose down
    ```
 
 ## Padrões de Commit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.9'
+services:
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - "8000:8000"
+  frontend:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
+    environment:
+      VITE_API_BASE_URL: http://localhost:8000
+    depends_on:
+      - backend
+    ports:
+      - "5173:5173"
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add docker-compose config for backend, frontend, Redis and Postgres
- document docker-compose usage in README

## Testing
- `cd backend && pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689a3d87ff08832fa1afecdfe93a8b24