### PR TITLE
Add CI workflow for linting, tests and security checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt flake8 bandit
+      - name: Lint
+        working-directory: backend
+        run: flake8 .
+      - name: Security analysis
+        working-directory: backend
+        run: bandit -r .
+      - name: Tests
+        working-directory: backend
+        run: pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Lint
+        working-directory: frontend
+        run: npm run lint
+      - name: Tests
+        working-directory: frontend
+        run: npm test -- --run


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Python and frontend checks
- include flake8 lint, bandit security scan, pytest, ESLint and Vitest

## Testing
- `python -m flake8 backend`
- `python -m bandit -r backend`
- `cd backend && pytest`
- `cd frontend && npm run lint`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689a44b5aae4832fa1e78d6dbea9f45f